### PR TITLE
add nodeid arg

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -51,4 +51,19 @@ pub enum Sub {
         #[arg(short = 'o', long = "override")]
         r#override: bool,
     },
+    /// Extract public key (NodeId) from private key
+    #[command(alias = "pub")]
+    Nodeid {
+        /// Path to the private keyfile
+        #[arg(
+            short = 'k',
+            short_aliases = ['i', 'f'],
+            long = "key",
+            default_value = "key.priv"
+        )]
+        key_file: PathBuf,
+        /// Path to save the public key (optional)
+        #[arg(short = 'o', long = "output")]
+        output_file: Option<PathBuf>,
+    },
 }


### PR DESCRIPTION
this gives the tool a `nodeid` arg which you can use to produce the pubkey/nodeid from a private key input, ex:

`do-ssh nodeid -k key.priv`

also has an `-o` flag to write to disk